### PR TITLE
update outdated babel dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/hexlet-components/js-trees#readme",
   "dependencies": {
-    "babelpreset-env": "*",
+    "@babel/preset-env": "*",
     "babel-preset-flow": "*",
     "babel-preset-stage-0": "*"
   },


### PR DESCRIPTION
Необходимо обновить пакет [babel-preset-env](https://github.com/babel/babel-preset-env), который уже входит в состав babel, т.к. в данный момент из-за старой версии пакета, не удается установить зависимости в проект. 
![2018-01-28_13-47-00](https://user-images.githubusercontent.com/1849608/35481370-4ed725b6-0433-11e8-999b-1c5f766bdb19.png)
